### PR TITLE
Clean up markdown and add ORR-ERD

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ Below is a list of NOAA Affiliated GitHub organizations with a link and brief de
 
 NOAA/PMEL conducts research to advance our knowledge of the global ocean and its interactions with the earth, atmosphere and ecosystems.<br>
 	
+### [NOAA Emergency Response Division (ERD)](https://github.com/NOAA-ORR-ERD)
+
+NOAA ERD Provides scientific and technical support to prepare for and respond to oil and chemical releases.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 This repository contains a list of GitHub accounts and repositories that are contributed to by NOAA staff from line offices and/or staff office throughout the organization. Below you will find the repository name, description, and GitHub address. Any additional questions about the projects should be referred to the GitHub administrator of these projects.  All NOAA Affiliated repositories and projects are subject to the following disclaimer: <br><br>
 
-<i>"This repository is a scientific product and is not official communication of the National Oceanic and Atmospheric Administration, or the United States Department of Commerce. All NOAA GitHub project code is provided on an 'as is' basis and the user assumes responsibility for its use. Any claims against the Department of Commerce or Department of Commerce bureaus stemming from the use of this GitHub project will be governed by all applicable Federal law. Any reference to specific commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply their endorsement, recommendation or favoring by the Department of Commerce. The Department of Commerce seal and logo, or the seal and logo of a DOC bureau, shall not be used in any manner to imply endorsement of any commercial product or activity by DOC or the United States Government."</i><br><br>
+*"This repository is a scientific product and is not official communication of the National Oceanic and Atmospheric Administration, or the United States Department of Commerce. All NOAA GitHub project code is provided on an 'as is' basis and the user assumes responsibility for its use. Any claims against the Department of Commerce or Department of Commerce bureaus stemming from the use of this GitHub project will be governed by all applicable Federal law. Any reference to specific commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply their endorsement, recommendation or favoring by the Department of Commerce. The Department of Commerce seal and logo, or the seal and logo of a DOC bureau, shall not be used in any manner to imply endorsement of any commercial product or activity by DOC or the United States Government."*
 
-<b>NOAA Affiliated Project Listing</b><br>
-Below is a list of NOAA Affiliated GitHub organizations with a link and brief description. More information on their repositories can be found in the README files of each page. <br><br>
 
-<b><a href="https://github.com/NOAA-PMEL">Pacific Marine Environmental Laboratory (PMEL)</a></b><br>
-	NOAA/PMEL conducts research to advance our knowledge of the global ocean and its interactions with the earth, atmosphere and ecosystems.<br>
+## NOAA Affiliated Project Listing
+
+Below is a list of NOAA Affiliated GitHub organizations with a link and brief description. More information on their repositories can be found in the README files of each page.
+
+### [Pacific Marine Environmental Laboratory (PMEL)](https://github.com/NOAA-PMEL)
+
+NOAA/PMEL conducts research to advance our knowledge of the global ocean and its interactions with the earth, atmosphere and ecosystems.<br>
 	


### PR DESCRIPTION
As gitHub renders these pages as Markdown, it's cleaner and more consistent to use Markdown for the markup. And easier for others to add to / edit.

If you really don't want to do this -- see my other PR for adding ORR-ERD in the old html format.

